### PR TITLE
PHP requirement is 7.2

### DIFF
--- a/docs/topics/prerequisites.md
+++ b/docs/topics/prerequisites.md
@@ -2,7 +2,7 @@
 
 In order to run the server, you'll need a server which
 
-* is capable of running Symfony 4. This means: PHP 7.1
+* is capable of running Symfony 4. This means: PHP 7.2
 * has git installed
 * has Composer installed
 * is able to load the repos. That means: Access to the internet is needed, also some free disk space.


### PR DESCRIPTION
The current install of the server fails with PHP 7.1, it requires 7.2.

I'm not sure if that applies to Symfony 4 too, or if it's only this server. The Symfony doc says 7.1 is enough: https://symfony.com/doc/current/setup.html

Also not sure what the second change in the PR is about. Newline change due to githubs code editor, maybe? Please ignore that.