### PR TITLE
Add Following symlinks

### DIFF
--- a/src/Service/Compiler/PackagesCompiler.php
+++ b/src/Service/Compiler/PackagesCompiler.php
@@ -115,6 +115,7 @@ class PackagesCompiler
         $files = [];
         $finder = new Finder();
         $finder->ignoreUnreadableDirs()
+            ->followLinks()
             ->in($recipe->getLocalPath())
             ->ignoreDotFiles(false);
 


### PR DESCRIPTION
Some recipes use symlinks (https://github.com/symfony/recipes/tree/master/doctrine/doctrine-bundle).
Add configuration to the finder to follow symlinks